### PR TITLE
Add ambar-record library

### DIFF
--- a/.github/workflows/ambar-record.yaml
+++ b/.github/workflows/ambar-record.yaml
@@ -1,0 +1,75 @@
+name: ambar-record
+on:
+  push:
+    paths:
+      - 'ambar-record/**'
+
+# only one build per branch
+concurrency:
+  group: build-record-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: GHC ${{ matrix.ghc }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        ghc: ['9.10.1']
+        cabal: ['3.10.3.0']
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup - GHC ${{ matrix.ghc }}
+        uses: haskell-actions/setup@v2
+        id: setup
+        with:
+          ghc-version: ${{ matrix.ghc }}
+          # Defaults, added for clarity:
+          cabal-version: ${{ matrix.cabal }}
+          cabal-update: true
+
+      - name: Build - Configure
+        run: |
+          cd ambar-record
+          cabal configure --enable-tests --enable-benchmarks
+          cabal build all --dry-run
+        # The last step generates dist-newstyle/cache/plan.json for the cache key.
+
+      - name: Build - Restore cached dependencies
+        uses: actions/cache/restore@v4
+        id: cache
+        env:
+          key: ${{ runner.os }}-ghc-${{ steps.setup.outputs.ghc-version }}-cabal-${{ steps.setup.outputs.cabal-version }}
+        with:
+          path: ${{ steps.setup.outputs.cabal-store }}
+          key: ${{ env.key }}-plan-${{ hashFiles('**/plan.json') }}
+          restore-keys: ${{ env.key }}-
+
+      - name: Build - Install dependencies
+        # If we had an exact cache hit, the dependencies will be up to date.
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          cd ambar-record
+          cabal build all --only-dependencies
+
+      # Cache dependencies already here, so that we do not have to rebuild them should the subsequent steps fail.
+      - name: Build - Save dependencies to cache
+        uses: actions/cache/save@v4
+        # If we had an exact cache hit, trying to save the cache would error because of key clash.
+        if: steps.cache.outputs.cache-hit != 'true'
+        with:
+          path: ${{ steps.setup.outputs.cabal-store }}
+          key: ${{ steps.cache.outputs.cache-primary-key }}
+
+      - name: Build
+        run: |
+          cd ambar-record
+          cabal build all
+
+      - name: Test
+        run: |
+          cd ambar-record
+          cabal run ambar-record-tests

--- a/ambar-record/README.md
+++ b/ambar-record/README.md
@@ -1,0 +1,7 @@
+# ambar-record
+
+This library contains Ambar's central internal representation for records ingested from client databases.
+
+It includes
+* Supported types within an Ambar record
+* How to encode and decode the record from supported formats (tagged binary and tagged JSON)

--- a/ambar-record/README.md
+++ b/ambar-record/README.md
@@ -2,6 +2,6 @@
 
 This library contains Ambar's central internal representation for records ingested from client databases.
 
-It includes
+It includes:
 * Supported types within an Ambar record
 * How to encode and decode the record from supported formats (tagged binary and tagged JSON)

--- a/ambar-record/ambar-record.cabal
+++ b/ambar-record/ambar-record.cabal
@@ -53,6 +53,7 @@ test-suite ambar-record-tests
         , bytestring
         , aeson
         , text
+        , time
         , hspec
         , base64
         , QuickCheck

--- a/ambar-record/ambar-record.cabal
+++ b/ambar-record/ambar-record.cabal
@@ -1,0 +1,58 @@
+cabal-version:      3.4
+name:               ambar-record
+version:            0.1.0.0
+synopsis:           Ambar's core record type
+license:            NONE
+author:             Ambar
+maintainer:         contact@ambar.cloud
+category:           Data
+build-type:         Simple
+
+common common
+    ghc-options: -Wall
+    default-language: GHC2021
+    default-extensions:
+        DerivingStrategies
+        LambdaCase
+        OverloadedStrings
+        RecordWildCards
+        TypeFamilies
+        TypeFamilyDependencies
+        DeriveAnyClass
+
+library
+    import:           common
+    hs-source-dirs:   src
+    exposed-modules:
+        Ambar.Record
+        Ambar.Record.Encoding
+        Ambar.Record.Encoding.TaggedBinary
+    build-depends:
+        base ^>=4.20.0.0
+        , aeson
+        , base64
+        , binary
+        , binary-instances
+        , bytestring
+        , containers
+        , hashable
+        , prettyprinter
+        , text
+        , time
+
+test-suite ambar-record-tests
+    import:           common
+    -- other-modules:
+    -- other-extensions:
+    type:             exitcode-stdio-1.0
+    hs-source-dirs:   test
+    main-is:          Main.hs
+    build-depends:
+        base ^>=4.20.0.0
+        , ambar-record
+        , bytestring
+        , aeson
+        , text
+        , hspec
+        , base64
+        , QuickCheck

--- a/ambar-record/ambar-record.cabal
+++ b/ambar-record/ambar-record.cabal
@@ -50,8 +50,9 @@ test-suite ambar-record-tests
     build-depends:
         base ^>=4.20.0.0
         , ambar-record
-        , bytestring
         , aeson
+        , bytestring
+        , containers
         , text
         , time
         , hspec

--- a/ambar-record/src/Ambar/Record.hs
+++ b/ambar-record/src/Ambar/Record.hs
@@ -1,0 +1,160 @@
+-- | The contents and types of Ambar records.
+module Ambar.Record where
+
+import Data.Aeson (FromJSON, ToJSON, parseJSON, toJSON)
+import qualified Data.Aeson as Json
+import qualified Data.Aeson.Types as Json
+import Data.Base64.Types (extractBase64)
+import Data.Binary (Binary)
+import qualified Data.Binary as Binary
+import Data.Binary.Instances.Aeson ()
+import Data.ByteString.Base64 (decodeBase64Untyped, encodeBase64)
+import Data.ByteString (ByteString)
+import Data.Char (toUpper)
+import Data.Hashable (Hashable)
+import Data.Int (Int64)
+import Data.List (stripPrefix)
+import Data.Maybe (fromMaybe)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Text
+import Data.Time (UTCTime)
+import Data.Time.Format.ISO8601 (iso8601ParseM)
+import Data.Word (Word64)
+import GHC.Generics (Generic)
+import Prettyprinter
+
+-- | A piece of data that is retrieved from a data source,
+-- stored in a queue and projected onto a data destination.
+newtype Record = Record
+  { content :: Content
+  }
+  deriving (Show, Generic, Eq)
+
+instance Binary Record
+
+type Content = [(Text, Value)]
+
+-- | A schema is an ordered list of key-value pairs.
+-- Every field is always optional.
+-- Backward-compatible updates are the ones that only ad new key-value pairs.
+newtype Schema = Schema [Field]
+  deriving newtype (ToJSON, FromJSON, Semigroup, Monoid)
+
+data Field = Field
+  { field_name :: Text
+  , field_type :: Type
+  }
+  deriving (Generic, Show)
+
+instance FromJSON Field
+instance ToJSON Field
+
+-- | The rich set of types that we support.
+data Type
+  -- base types
+  = TBoolean
+  | TUInteger
+  | TInteger
+  | TReal
+  | TString
+  | TBytes
+  | TJSON
+  -- rich types
+  | TDateTime
+  deriving (Generic, Show, Eq, Enum, Bounded, Ord)
+
+-- | Case insensitive parsing.
+instance FromJSON Type where
+  parseJSON = Json.withText "Type" $ \t ->
+    case lookup (uppercase t) mapping of
+      Just ty -> return ty
+      Nothing -> Json.parseFail $ "Unknown type '" <> Text.unpack t <> "'"
+    where
+    mapping :: [(Text, Type)]
+    mapping =
+      [ (name, ty)
+      | ty <- [minBound..] :: [Type]
+      , let name = removeT $ uppercase $ Text.pack $ show ty
+      ]
+    uppercase = Text.toUpper
+    removeT s = fromMaybe s (Text.stripPrefix "T" s)
+
+instance ToJSON Type
+  where toJSON = Json.genericToJSON optionsType
+
+optionsType :: Json.Options
+optionsType = Json.defaultOptions
+  { Json.constructorTagModifier = \label ->
+      fromMaybe label (stripPrefix "T" label)
+  }
+
+-- | One constructor for each inhabitant of Type
+data Value
+  = Boolean Bool
+  | UInt Word64
+  | Int Int64
+  | Real Double
+  | String Text
+  | Binary Bytes
+  | Json Text Json.Value
+    -- ^ a Json value contains the original text provided by the client.
+  | DateTime TimeStamp
+  | Null
+  deriving (Show, Generic, Eq, Hashable)
+
+-- | A timestamp value with the original timestamp string value.
+data TimeStamp = TimeStamp Text UTCTime
+  deriving (Eq, Hashable)
+  deriving stock (Show, Generic)
+
+instance Binary TimeStamp where
+  put (TimeStamp txt _) = Binary.put txt
+  get = do
+    txt <- Binary.get
+    time <- iso8601ParseM (Text.unpack txt)
+    return $ TimeStamp txt time
+
+instance ToJSON TimeStamp where
+  toJSON (TimeStamp txt _) = toJSON txt
+
+instance FromJSON TimeStamp where
+  parseJSON = Json.withText "TimeStamp" $ \txt ->
+    TimeStamp txt <$> iso8601ParseM (Text.unpack txt)
+
+instance Binary Value
+
+instance FromJSON Value
+  where parseJSON = Json.genericParseJSON options
+instance ToJSON Value
+  where toJSON = Json.genericToJSON options
+
+options :: Json.Options
+options = Json.defaultOptions
+  { Json.sumEncoding = Json.ObjectWithSingleField
+  , Json.constructorTagModifier = map toUpper
+  }
+
+newtype Bytes = Bytes ByteString
+  deriving newtype (Binary, Eq, Hashable)
+
+toBase64 :: Bytes -> Text
+toBase64 (Bytes bs) = extractBase64 $ encodeBase64 bs
+
+instance Show Bytes where
+  show bytes = "Bytes " <> show (pretty bytes)
+
+instance Pretty Bytes where
+  pretty bytes = pretty $ show $ Text.unpack $ toBase64 bytes
+
+instance ToJSON Bytes where
+  toJSON bytes = Json.String (toBase64 bytes)
+
+instance FromJSON Bytes where
+  parseJSON = Json.withText "Bytes" $ \txt ->
+    either fail return (fromBase64 txt)
+    where
+    fromBase64 txt =
+      case decodeBase64Untyped (Text.encodeUtf8 txt) of
+        Left err -> Left $ Text.unpack err
+        Right v -> Right $ Bytes v

--- a/ambar-record/src/Ambar/Record/Encoding.hs
+++ b/ambar-record/src/Ambar/Record/Encoding.hs
@@ -25,7 +25,7 @@ class Decode a where
 
 -- | This is the format we currently use for records in Kafka.
 newtype TaggedJson = TaggedJson (Map Text Value)
-  deriving newtype (ToJSON, FromJSON)
+  deriving newtype (ToJSON, FromJSON, Show)
 
 instance Encode TaggedJson where
   encode (Record fields) = TaggedJson $ Map.fromList fields

--- a/ambar-record/src/Ambar/Record/Encoding.hs
+++ b/ambar-record/src/Ambar/Record/Encoding.hs
@@ -53,6 +53,6 @@ instance Encode Json.Value where
       Real x -> toJSON x
       String x -> toJSON x
       Binary (Bytes x) -> Json.String $ extractBase64 $ encodeBase64 x
-      Json txt _ -> toJSON txt
+      Json val -> val
       DateTime x -> toJSON x
       Null -> Json.Null

--- a/ambar-record/src/Ambar/Record/Encoding.hs
+++ b/ambar-record/src/Ambar/Record/Encoding.hs
@@ -1,0 +1,58 @@
+{-| Record encoding is about the format in which records are kept in queue.
+   The goals are to enable fast filtering and efficient storage.
+-}
+module Ambar.Record.Encoding
+  ( Encode(..)
+  , Decode(..)
+  , TaggedJson
+  ) where
+
+import qualified Data.Aeson as Json
+import Data.Aeson (ToJSON(..), FromJSON)
+import Data.Base64.Types (extractBase64)
+import Data.ByteString.Base64 (encodeBase64)
+import Data.Map (Map)
+import qualified Data.Map as Map
+import Data.Text (Text)
+
+import Ambar.Record (Record(..), Schema, Value(..), Bytes(..))
+
+class Encode a where
+  encode :: Record -> a
+
+class Decode a where
+  decode :: Schema -> a -> Either Text Record
+
+-- | This is the format we currently use for records in Kafka.
+newtype TaggedJson = TaggedJson (Map Text Value)
+  deriving newtype (ToJSON, FromJSON)
+
+instance Encode TaggedJson where
+  encode (Record fields) = TaggedJson $ Map.fromList fields
+
+instance Decode TaggedJson where
+  decode _ (TaggedJson bs) = Right $ Record $ Map.toList bs
+
+instance Encode Record where
+  encode = id
+
+instance Decode Record where
+  decode _ = Right
+
+instance Encode Json.Value where
+  encode (Record fields) =
+    Json.toJSON $ Map.fromList
+      [ (name, untagged value)
+      | (name, value) <- fields
+      ]
+    where
+    untagged = \case
+      Boolean x -> toJSON x
+      Int x -> toJSON x
+      UInt x -> toJSON x
+      Real x -> toJSON x
+      String x -> toJSON x
+      Binary (Bytes x) -> Json.String $ extractBase64 $ encodeBase64 x
+      Json txt _ -> toJSON txt
+      DateTime x -> toJSON x
+      Null -> Json.Null

--- a/ambar-record/src/Ambar/Record/Encoding/TaggedBinary.hs
+++ b/ambar-record/src/Ambar/Record/Encoding/TaggedBinary.hs
@@ -9,12 +9,14 @@ import qualified Data.Binary.Put as Put
 import qualified Data.ByteString as BS
 import Data.ByteString.Lazy (ByteString)
 import qualified Data.ByteString.Lazy as LB
+import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import Control.Monad (unless)
 import Data.Text (Text, pack)
 import Data.Text.Encoding (encodeUtf8, decodeUtf8)
+import Data.Time.Format.ISO8601 (iso8601ParseM)
 
-import Ambar.Record (Record(..), Value(..), Bytes(..))
+import Ambar.Record (Record(..), Value(..), Bytes(..), TimeStamp(..))
 import Ambar.Record.Encoding (Encode(..), Decode(..))
 
 newtype TaggedBinary = TaggedBinary ByteString
@@ -53,7 +55,7 @@ instance Encode TaggedBinary where
           $ Builder.fromLazyByteString
           $ LB.fromStrict
           $ Text.encodeUtf8 txt
-        DateTime txt -> string txt
+        DateTime (TimeStamp txt _) -> string txt
         Null -> mempty
 
       tag :: Value -> Builder
@@ -140,7 +142,10 @@ instance Decode TaggedBinary where
 
     real = Real <$> Get.getDoublebe
 
-    datetime = DateTime <$> string
+    datetime = do
+      txt <- string
+      time <- iso8601ParseM (Text.unpack txt)
+      return $ DateTime (TimeStamp txt time)
 
     json = do
       bs <- bytestring

--- a/ambar-record/src/Ambar/Record/Encoding/TaggedBinary.hs
+++ b/ambar-record/src/Ambar/Record/Encoding/TaggedBinary.hs
@@ -1,0 +1,157 @@
+module Ambar.Record.Encoding.TaggedBinary (TaggedBinary(..)) where
+
+import qualified Data.Aeson as Aeson
+import Data.Binary.Builder (Builder)
+import qualified Data.Binary.Builder as Builder
+import qualified Data.Binary.Get as Get
+import Data.Binary.Get (Get)
+import qualified Data.Binary.Put as Put
+import qualified Data.ByteString as BS
+import Data.ByteString.Lazy (ByteString)
+import qualified Data.ByteString.Lazy as LB
+import qualified Data.Text.Encoding as Text
+import Control.Monad (unless)
+import Data.Text (Text, pack)
+import Data.Text.Encoding (encodeUtf8, decodeUtf8)
+
+import Ambar.Record (Record(..), Value(..), Bytes(..))
+import Ambar.Record.Encoding (Encode(..), Decode(..))
+
+newtype TaggedBinary = TaggedBinary ByteString
+
+instance Encode TaggedBinary where
+  encode (Record fields) = TaggedBinary $ Builder.toLazyByteString encoded
+    where
+    encoded = versionTag <> withLength pairs
+
+    withLength builder = length' <> content
+      where
+        bs = Builder.toLazyByteString builder
+        length' = Builder.putWord64be (fromIntegral $ LB.length bs)
+        content = Builder.fromLazyByteString bs
+
+    versionTag = Builder.singleton 1
+
+    pairs = foldMap pair fields
+
+    pair (k, v) = string k <> value v
+
+    string k = withLength str
+      where str = Builder.fromLazyByteString $ LB.fromStrict $ encodeUtf8 k
+
+    value v = tag v <> content v
+      where
+      content = \case
+        Boolean True  -> Builder.singleton 0xFF
+        Boolean False -> Builder.singleton 0x00
+        Int n -> Put.execPut $ Put.putInt64be n
+        UInt n -> Builder.putWord64be n
+        Real n -> Put.execPut $ Put.putDoublebe n
+        String t -> string t
+        Binary (Bytes b) -> withLength (Builder.fromByteString b)
+        Json txt _ -> withLength
+          $ Builder.fromLazyByteString
+          $ LB.fromStrict
+          $ Text.encodeUtf8 txt
+        DateTime txt -> string txt
+        Null -> mempty
+
+      tag :: Value -> Builder
+      tag = Builder.singleton . \case
+        Boolean _ -> 0
+        UInt _ -> 1
+        Int _ -> 2
+        Real _ -> 3
+        String _ -> 4
+        Binary _ -> 5
+        DateTime _ -> 6
+        Json _ _ -> 7
+        Null -> 8
+
+instance Decode TaggedBinary where
+  decode _ (TaggedBinary raw) =
+    case Get.runGetOrFail record raw of
+      Left (_,_,err) -> Left $ "unable to decode binary record: " <> pack err
+      Right (_,_,r) -> Right r
+    where
+    record = do
+      checkVersion
+      pairs <- manyWithLength pair
+      checkEnd
+      return $ Record pairs
+
+    checkVersion = do
+      v <- Get.getWord8
+      unless (v == 1) $ fail $
+        "Incorrect version. Expected 0 but got " <> show v
+
+    checkEnd = do
+      finished <- Get.isEmpty
+      unless finished $ do
+        here <- Get.bytesRead
+        let total = LB.length raw
+            remaining = total - here
+        fail $ "extra " <> show remaining <> " bytes at the end of value"
+
+    manyWithLength decodeOne = do
+      total <- Get.getWord64be
+      start <- Get.bytesRead
+      let consume xs = do
+            here <- Get.bytesRead
+            let consumed = fromIntegral $ here - start
+                done = consumed >= total
+            if done
+               then return (reverse xs)
+               else do
+                 x <- decodeOne
+                 consume (x:xs)
+      consume []
+
+    pair :: Get.Get (Text, Value)
+    pair = do
+      key <- string
+      val <- value
+      return (key, val)
+
+    value = do
+      tag <- Get.getWord8
+      case tag of
+        0 -> boolean
+        1 -> uint
+        2 -> int
+        3 -> real
+        4 -> String <$> string
+        5 -> Binary . Bytes <$> bytestring
+        6 -> datetime
+        7 -> json
+        8 -> return Null
+        _ -> fail $ "unknown tag: " <> show tag
+
+    boolean = do
+      val <- Get.getWord8
+      case val of
+        0x00 -> return $ Boolean False
+        0xFF -> return $ Boolean True
+        _ -> fail $ "unknown boolean code: " <> show val
+
+    uint = UInt . fromIntegral <$> Get.getWord64be
+
+    int = Int . fromIntegral <$> Get.getInt64be
+
+    real = Real <$> Get.getDoublebe
+
+    datetime = DateTime <$> string
+
+    json = do
+      bs <- bytestring
+      case Aeson.eitherDecode (LB.fromStrict bs) of
+        Left err -> fail $ "unable to decode json field: " <> show err
+        Right val -> return $ Json (Text.decodeUtf8 bs) val
+
+    string :: Get Text
+    string = decodeUtf8 <$> bytestring
+
+    bytestring :: Get BS.ByteString
+    bytestring = do
+      len <- Get.getWord64be
+      Get.getByteString (fromIntegral len)

--- a/ambar-record/test/Main.hs
+++ b/ambar-record/test/Main.hs
@@ -1,0 +1,144 @@
+{-# OPTIONS_GHC -Wno-orphans #-}
+module Main (main) where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as LB
+import Data.ByteString.Base64 (encodeBase64)
+import GHC.IsList (fromList)
+import Data.Proxy (Proxy(..))
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Text
+import Test.Hspec (Spec, describe, it, shouldBe)
+import Test.QuickCheck (Arbitrary(..), Gen, property, arbitrary)
+import qualified Test.QuickCheck as Q
+
+import Ambar.Record (Record(..), Value(..), Bytes(..))
+import Ambar.Record.Encoding (Encode, Decode, encode, decode)
+import Ambar.Record.Encoding.TaggedBinary (TaggedBinary(..))
+
+main :: IO ()
+main = hspec testEncodings
+
+testEncodings :: Spec
+testEncodings = describe "encoding" $ do
+  describe "TaggedBinary" $ do
+    it "model-checking" $ run @TaggedBinary Proxy
+    describe "golden test" $ do
+      let test :: [(Text, Value)] -> Text -> IO ()
+          test fields result = do
+            let TaggedBinary encoded = encode (Record fields)
+            encodeBase64 (BS.toStrict encoded) `shouldBe` result
+      it "Boolean" $ test [("field_Boolean", Boolean False) ] "AQAAAAAAAAAXAAAAAAAAAA1maWVsZF9Cb29sZWFuAAA="
+      it "UInteger" $ test [("field_UInteger", UInt 1)] "AQAAAAAAAAAfAAAAAAAAAA5maWVsZF9VSW50ZWdlcgEAAAAAAAAAAQ=="
+      it "Integer" $ test [("field_Integer", Int (-1))] "AQAAAAAAAAAeAAAAAAAAAA1maWVsZF9JbnRlZ2VyAv//////////"
+      it "Real" $ test [("field_Real", Real 1.5)] "AQAAAAAAAAAbAAAAAAAAAApmaWVsZF9SZWFsAz/4AAAAAAAA"
+      it "String" $ test [("field_String", String "wat")] "AQAAAAAAAAAgAAAAAAAAAAxmaWVsZF9TdHJpbmcEAAAAAAAAAAN3YXQ="
+      it "Bytes" $ test [("field_Bytes", Binary (Bytes "abc"))] "AQAAAAAAAAAfAAAAAAAAAAtmaWVsZF9CeXRlcwUAAAAAAAAAA2FiYw=="
+      it "JSON" $ test
+        [("field_JSON", jsonValue $ Aeson.Object $ fromList
+          [ ("null", Aeson.Null)
+          , ("string", Aeson.String "some_string")
+          , ("number", Aeson.Number 9)
+          , ("array", Aeson.Array $ fromList [Aeson.Number 1])
+          , ("bool", Aeson.Bool True)
+          , ("object" , Aeson.Object $ fromList [("first", Aeson.Bool True)])
+          ]
+        )] "AQAAAAAAAAB6AAAAAAAAAApmaWVsZF9KU09OBwAAAAAAAABfeyJhcnJheSI6WzFdLCJib29sIjp0cnVlLCJudWxsIjpudWxsLCJudW1iZXIiOjksIm9iamVjdCI6eyJmaXJzdCI6dHJ1ZX0sInN0cmluZyI6InNvbWVfc3RyaW5nIn0="
+      it "DateTime" $ test [("field_DateTime", DateTime "2024-01-23T00:26:17")] "AQAAAAAAAAAyAAAAAAAAAA5maWVsZF9EYXRlVGltZQYAAAAAAAAAEzIwMjQtMDEtMjNUMDA6MjY6MTc="
+      it "all" $  do
+        let record = Record
+              [ ("field_Boolean", Boolean False)
+              , ("field_UInteger", UInt 1)
+              , ("field_Integer", Int (-1))
+              , ("field_Real", Real 1.5)
+              , ("field_String", String "wat")
+              , ("field_Bytes", Binary (Bytes "abc"))
+              , ("field_JSON", jsonValue $ Aeson.Object $ fromList
+                  [ ("null", Aeson.Null)
+                  , ("string", Aeson.String "some_string")
+                  , ("number", Aeson.Number 9)
+                  , ("array", Aeson.Array $ fromList [Aeson.Number 1])
+                  , ("bool", Aeson.Bool True)
+                  , ("object" , Aeson.Object $ fromList [("first", Aeson.Bool True)])
+                  ]
+                )
+              , ("field_DateTime", DateTime "2024-01-23T00:26:17")
+              ]
+        let TaggedBinary encoded = encode record
+            expected = "AQAAAAAAAAFaAAAAAAAAAA1maWVsZF9Cb29sZWFuAAAAAAAAAAAADmZpZWxkX1VJbnRlZ2VyAQAAAAAAAAABAAAAAAAAAA1maWVsZF9JbnRlZ2VyAv//////////AAAAAAAAAApmaWVsZF9SZWFsAz/4AAAAAAAAAAAAAAAAAAxmaWVsZF9TdHJpbmcEAAAAAAAAAAN3YXQAAAAAAAAAC2ZpZWxkX0J5dGVzBQAAAAAAAAADYWJjAAAAAAAAAApmaWVsZF9KU09OBwAAAAAAAABfeyJhcnJheSI6WzFdLCJib29sIjp0cnVlLCJudWxsIjpudWxsLCJudW1iZXIiOjksIm9iamVjdCI6eyJmaXJzdCI6dHJ1ZX0sInN0cmluZyI6InNvbWVfc3RyaW5nIn0AAAAAAAAADmZpZWxkX0RhdGVUaW1lBgAAAAAAAAATMjAyNC0wMS0yM1QwMDoyNjoxNw=="
+        encodeBase64 (BS.toStrict encoded) `shouldBe` expected
+  where
+    run :: forall a. (Encode a, Decode a) => Proxy a -> Q.Property
+    run _ = Q.withMaxSuccess 1000 $ property $ \record -> do
+      let schema = error "decoding using schemas not implemented yet"
+      decode schema (encode record :: a) `shouldBe` Right record
+
+instance Arbitrary Record where
+  arbitrary = Record <$> pairs
+    where
+    pairs :: Gen [(Text, Value)]
+    pairs = Q.resize 10 (Q.listOf pair)
+
+    pair :: Gen (Text, Value)
+    pair = do
+      FieldName key <- arbitrary
+      value <- arbitrary
+      return (key, value)
+
+  shrink (Record content) =
+    case content of
+      [] -> []
+      -- if it has one field, shrink the key and value
+      [(k, v)] -> Record <$>
+        [ pure (key, value)
+        | FieldName key <- shrink (FieldName k)
+        , value <- shrink v
+        ]
+      -- if it has multiple fields, create records with a single field
+      pairs -> Record <$>
+        [ pure (key, value)
+        | (key, value) <- pairs
+        ]
+
+instance Arbitrary Value where
+  arbitrary = Q.oneof
+    [ Boolean <$> Q.arbitraryBoundedEnum
+    , Int <$> arbitrary
+    , UInt <$> arbitrary
+    , Real <$> arbitrary
+    , do
+        FieldName n <- arbitrary
+        return $ String n
+      -- binary of up to 1Kb
+    , Binary . Bytes . BS.pack <$> Q.resize 1024 (Q.listOf arbitrary)
+    , do
+        FieldName n <- arbitrary
+        return $ DateTime n
+    , return $ jsonValue Aeson.Null
+    , return Null
+    ]
+
+  shrink = \case
+    Boolean _ -> []
+    Int n -> Int <$> shrink n
+    UInt n -> UInt <$> shrink n
+    Real n -> Real <$> shrink n
+    String txt -> String . unFieldName <$> shrink (FieldName txt)
+    Binary (Bytes bs) -> Binary . Bytes <$> BS.tails bs
+    DateTime txt -> DateTime . unFieldName <$> shrink (FieldName txt)
+    Json _ json -> jsonValue <$> shrink json
+    Null -> []
+
+jsonValue :: Aeson.Value -> Value
+jsonValue value = Json (Text.decodeUtf8 $ LB.toStrict $ Aeson.encode value) value
+
+-- A text of an appropriate length to be used as the name of a field
+newtype FieldName = FieldName { unFieldName :: Text }
+
+instance Arbitrary FieldName where
+  -- A piece of text of pu to 20 characters.
+  arbitrary = FieldName . Text.pack <$> Q.resize 20 (Q.listOf arbitrary)
+
+  shrink (FieldName txt) = FieldName <$> reverse (Text.tails txt)

--- a/ambar-record/utils.sh
+++ b/ambar-record/utils.sh
@@ -1,0 +1,36 @@
+#! /bin/bash
+
+function build {
+  cabal build ambar-record -j "${@}"
+}
+
+function build-docs {
+  cabal haddock
+}
+
+function test {
+  cabal run ambar-record-tests -- "${@}"
+}
+
+function typecheck {
+  # Start fast type-checking of the library. (Everything but Main.hs)
+  # Watches your files and type-checks on save
+  ghcid -c 'cabal v2-repl' ambar-record "${@}"
+}
+
+function typecheck-tests {
+  # Start fast type-checking of the executable. (Just Main.hs)
+  # Watches your files and type-checks on save
+  ghcid -c 'cabal v2-repl' ambar-record-tests "${@}"
+}
+
+# If the first argument is a function run it.
+if [[ $(type -t $1) == function ]];
+  then
+   $1 "${@:2}";
+  else
+    echo "Development utilities"
+    echo ""
+    echo "  ./util.sh COMMAND"
+    echo ""
+fi


### PR DESCRIPTION
This library contains Ambar's central internal representation for records ingested from client databases.